### PR TITLE
tmp file is now in system tmp to make sure it gets cleared

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+var os      = require('os')
 var cont    = require('cont')
 var pull    = require('pull-stream')
 var defer   = require('pull-defer')
@@ -26,13 +27,14 @@ function toArray (h) {
 var Blobs = module.exports = function (dir) {
   var n = 0
   var waiting = [], tmp = false
+  var tmpdir = path.join(os.tmpdir(), 'blobs-'+Date.now()+((Math.random()*1000000)|0))
 
   function mktmp (cb) {
     if(tmp) return cb()
     else waiting.push(cb)
   }
 
-  mkdirp(path.join(dir, 'tmp'), function () {
+  mkdirp(tmpdir, function () {
     tmp = true; while(waiting.length) waiting.shift()()
   })
 
@@ -114,7 +116,7 @@ var Blobs = module.exports = function (dir) {
       var deferred = defer.sink()
 
       mktmp(function () {
-        var tmpfile = path.join(dir, 'tmp', Date.now() + '-' + n++)
+        var tmpfile = path.join(tmpdir, Date.now() + '-' + n++)
         var hasher = createHash()
 
         var ws = write(tmpfile, function (err) {

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ function toArray (h) {
 var Blobs = module.exports = function (dir) {
   var n = 0
   var waiting = [], tmp = false
-  var tmpdir = path.join(os.tmpdir(), 'blobs-'+Date.now()+((Math.random()*1000000)|0))
+  var tmpdir = path.join(os.tmpdir(), 'blobs-'+dir.replace(/\//g, '-'))
 
   function mktmp (cb) {
     if(tmp) return cb()


### PR DESCRIPTION
https://github.com/ssbc/scuttlebot/issues/89

i suspect that the old tmp dir was under the base path so that multiple multiblob instances wouldnt interfere with each other. i think this will preserve that property while using the system tmp, which has the added benefit of getting cleared periodically by the system
