### PR TITLE
Handle stat error

### DIFF
--- a/index.js
+++ b/index.js
@@ -175,8 +175,10 @@ var Blobs = module.exports = function (config) {
 
       var stream = defer.source()
       stat(toPath(dir, hash), function (err, stat) {
-        if(err) return cb(err)
-        if(opts.size != null && opts.size !== stat.size)
+        if(err)
+          stream.abort(explain(err, 'stat failed'))
+
+        else if(opts.size != null && opts.size !== stat.size)
           stream.abort(new Error('incorrect file length,'
             + ' requested:' + opts.size + ' file was:' + stat.size
             + ' for file:' + hash


### PR DESCRIPTION
```
ReferenceError: cb is not defined
    at /home/cel/src/multiblob/index.js:178:24
    at done (/home/cel/src/multiblob/index.js:41:38)
    at FSReqWrap.oncomplete (fs.js:114:15)
```