### PR TITLE
Add getSlice method

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ If the argument is an `opts` object, with the `key: hash` property,
 retrive that blob, but error if the size does not exactly match the
 `size` property, or is over `max` property (in bytes)
 
+### getSlice (opts) => Source
+
+create a source stream that reads a slice of a given blob,
+from the `start` property to the `end` property, in bytes.
+Error if the file does not exist or if
+the size of the whole blob does not exactly match the
+`size` property, or is over `max` property (in bytes).
+
 ### has(hash, cb)
 
 check if the given hash is in the store.

--- a/test/slice.js
+++ b/test/slice.js
@@ -1,0 +1,70 @@
+var tape = require('tape')
+
+var util = require('../util')
+var Blobs = require('../')
+
+var pull   = require('pull-stream')
+var crypto = require('crypto')
+var rimraf = require('rimraf')
+var path = require('path')
+var osenv = require('osenv')
+
+var dirname = path.join(osenv.tmpdir(), 'test-multiblob')
+rimraf.sync(dirname)
+
+var l = 100, random1 = []
+while(l --) random1.push(crypto.randomBytes(1024))
+
+module.exports = function (alg) {
+
+var blobs = Blobs(dirname)
+
+function hasher (ary) {
+  var hasher = util.createHash(alg, true)
+  pull(pull.values(ary), hasher, pull.drain())
+  return util.encode(hasher.digest, alg)
+}
+
+var hash1 = hasher(random1)
+
+tape('read a slice', function (t) {
+  pull(
+    pull.values(random1),
+    blobs.add(function (err, hash) {
+      t.error(err, 'add data')
+      pull(
+        blobs.getSlice({hash: hash, start: 10*1024, end: 80*1024}),
+        pull.collect(function (err, bufs) {
+          t.error(err, 'slice')
+          var buf = Buffer.concat(bufs)
+          t.deepEqual(buf, Buffer.concat(random1).slice(10*1024, 80*1024))
+          t.end()
+        })
+      )
+    })
+  )
+})
+
+tape('error if requested size is incorrect', function (t) {
+  pull(
+    blobs.getSlice({hash: hash1, start: 10*1024, end: 80*1024, size: 7}),
+    pull.collect(function (err) {
+      t.ok(err)
+      t.end()
+    })
+  )
+})
+
+tape('error if size is over max', function (t) {
+  pull(
+    blobs.getSlice({hash: hash1, start: 10*1024, end: 80*1024, max: 100*1024-1}),
+    pull.collect(function (err) {
+      t.ok(err)
+      t.end()
+    })
+  )
+})
+
+}
+
+if(!module.parent) module.exports('blake2s')


### PR DESCRIPTION
This is for reading a blob at a given byte offset and length, which is useful for various applications.

Previously: `%7M0SCtSpRzoDv6Fa/4Ev/7tYYVIVaCo7Izt0PNL5FyI=.sha256`, `%ehrTI23sCvgc7+fz/G+O1X80mPWpyu8YsnJECuCVs2Y=.sha256`, `%jBYA4vcgmsmaJd8TdczI1dtx3jIvVJF6RuaWEui9X50=.sha256`

This feature is implemented as a new method rather than adding more options to `get`, so that an application can detect the presence of this feature.