### PR TITLE
bump rc to version 1.2.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: node_js
+node_js:
+  - 6
+  - 8
+  - 10

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "pull-paramap": "^1.2.2",
     "pull-stream": "^3.6.2",
     "pull-write-file": "^0.2.1",
-    "rc": "~0.5.4",
+    "rc": "~1.2.8",
     "rimraf": "~2.2.8",
     "stream-to-pull-stream": "^1.7.2"
   },


### PR DESCRIPTION
updates ssbc/scuttlebot#528 and closes #7 

also two bits of meta-cleanup for good measure:
* added node_modules to .gitignore
* added a basic .travis.yml