### PR TITLE
Redact sensitive information from pull-file error

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,10 @@ function readFile (...args) {
   return pull(
     Read(...args),
     Catch(err => {
+      if (err.code !== 'ENOENT') {
+        console.error(new Error(err))
+      }
+
       err.message = 'could not get blob'
 
       // delete sensitive metadata

--- a/index.js
+++ b/index.js
@@ -26,9 +26,7 @@ function readFile (...args) {
   return pull(
     Read(...args),
     Catch(err => {
-      if (err.code === 'ENOENT' ) {
-        err.message = 'blob not found'
-      }
+      err.message = 'could not get blob'
 
       // delete sensitive metadata
       err.path = null

--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ function readFile (...args) {
     Read(...args),
     Catch(err => {
       if (err.code !== 'ENOENT') {
-        console.error(new Error(err))
+        console.error(err.toString())
       }
 
       err.message = 'could not get blob'

--- a/index.js
+++ b/index.js
@@ -40,10 +40,6 @@ function readFile (...args) {
 
       err.message = 'could not get blob'
 
-      // delete sensitive metadata
-      err.path = null
-      err.dest = null
-
       return false // pass along error
     })
   )

--- a/index.js
+++ b/index.js
@@ -22,6 +22,14 @@ function write (filename, cb) {
   return WriteFile(filename, cb)
 }
 
+/**
+ * Wraps the `pull-file` function module with two changes: errors are redacted,
+ * and any error except ENOENT (file not found) will be logged to the server.
+ *
+ * @param {...object} args - arguments to pass to `pull-file`
+ *
+ * @return {function} pull-stream source, to be consumed by a through or sink
+ */
 function readFile (...args) {
   return pull(
     Read(...args),

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "explain-error": "~1.0.1",
     "mkdirp": "~0.5.0",
     "pull-cat": "^1.1.8",
+    "pull-catch": "^1.0.0",
     "pull-defer": "^0.2.2",
     "pull-file": "^0.5.0",
     "pull-glob": "~1.0.6",

--- a/test/slice.js
+++ b/test/slice.js
@@ -63,8 +63,6 @@ tape('error if requested hash is missing', function (t) {
       t.ok(err, 'error message exists')
       t.equal(err.code, 'ENOENT', 'error code is unchanged')
       t.equal(err.message, 'could not get blob', 'error message is correctly delcared')
-      t.notOk(err.path, 'do not include file path')
-      t.notOk(err.dest, 'does not include destination')
       t.end()
     })
   )

--- a/test/slice.js
+++ b/test/slice.js
@@ -62,7 +62,7 @@ tape('error if requested hash is missing', function (t) {
 
       t.ok(err, 'error message exists')
       t.equal(err.code, 'ENOENT', 'error code is unchanged')
-      t.equal(err.message, 'blob not found', 'error message is correctly delcared')
+      t.equal(err.message, 'could not get blob', 'error message is correctly delcared')
       t.notOk(err.path, 'do not include file path')
       t.notOk(err.dest, 'does not include destination')
       t.end()


### PR DESCRIPTION
Resolves https://github.com/ssbc/patchwork/issues/877.

## Before

```json
{
  "message": "ENOENT: no such file or directory, open '/home/christianbundy/.ssb/blobs/sha256/ff/aabb24e2b2b618279f3a01239c71be8b42af91de16400865202ea878997cbc'",
  "name": "Error",
  "stack": "Error: ENOENT: no such file or directory, open '/home/christianbundy/.ssb/blobs/sha256/ff/aabb24e2b2b618279f3a01239c71be8b42af91de16400865202ea878997cbc'"
}
```

## After

```json
{
  "message": "could not get blob",
  "name": "Error",
  "stack": "Error: could not get blob"
}
```