### PR TITLE
Add stack trace for file read errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ function readFile (...args) {
     Read(...args),
     Catch(err => {
       if (err.code !== 'ENOENT') {
-        console.error(err.toString())
+        console.error(new Error(err))
       }
 
       err.message = 'could not get blob'


### PR DESCRIPTION
Resolves #11, but does *not* resolve the EBADF error. Also, this prints "Error: Error:" which is annoying but I don't know how to get around it.

## Before

```
Error: EBADF: bad file descriptor, close
```

## After

```
Error: Error: EBADF: bad file descriptor, close
    at err (/home/christianbundy/src/ssbc/multiblob/index.js:38:23)
    at onNext (/home/christianbundy/src/ssbc/multiblob/node_modules/pull-catch/index.js:9:32)
    at /home/christianbundy/src/ssbc/multiblob/node_modules/pull-file/index.js:83:16
    at FSReqWrap.oncomplete (fs.js:135:15)
```