### PR TITLE
Ignore EBADF error

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,23 +18,25 @@ var Catch    = require('pull-catch')
 var u = require('./util')
 var createHash = u.createHash
 
-function write (filename, cb) {
-  return WriteFile(filename, cb)
-}
-
 /**
  * Wraps the `pull-file` function module with two changes: errors are redacted,
- * and any error except ENOENT (file not found) will be logged to the server.
+ * and any errors except ENOENT and EBADF will be logged to the server.
  *
  * @param {...object} args - arguments to pass to `pull-file`
  *
  * @return {function} pull-stream source, to be consumed by a through or sink
  */
 function readFile (...args) {
+
+  const ignoredErrorCodes = [
+    'ENOENT',
+    'EBADF'
+  ]
+
   return pull(
     Read(...args),
     Catch(err => {
-      if (err.code !== 'ENOENT') {
+      if (ignoredErrorCodes.includes(err.code) === false) {
         console.error(new Error(err))
       }
 


### PR DESCRIPTION
This ignores the EBADF errors that are being thrown constantly.

I think that bug should be tracked in https://github.com/pull-stream/pull-file/issues/6, but I'd like to reduce the number of errors being logged since they seem to be harmless.

I've also removed the `write()` function above, since it isn't used anywhere.